### PR TITLE
Update first-mate dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/MagicStack/syntaxdev"
   },
   "dependencies": {
-    "first-mate": "^5.0.2",
+    "first-mate": "^6.2.0",
     "js-yaml": "^3.4.2",
     "temp": "^0.8.3",
     "argparse": "^1.0.2",


### PR DESCRIPTION
This updates first-mate, which also brings an update to its
dependencies, including oniguruma, which otherwise crashes
on current versions of Node (7.1 for sure).