### PR TITLE
Improve reporting of YAML parsing errors.

### DIFF
--- a/bin/syntaxdev.js
+++ b/bin/syntaxdev.js
@@ -6,6 +6,7 @@
 var syntaxdev = require('../index'),
     argparse = require('argparse'),
     packageInfo = require('../package.json'),
+    yaml = require('js-yaml'),
     _ = require('underscore');
 
 
@@ -84,22 +85,31 @@ buildPListCli.addArgument([ '--out' ], {
 function main() {
     var options = cli.parseArgs();
 
-    if (options.command == 'test') {
-        syntaxdev.test(
-            _.chain(options.tests).flatten().uniq().sort().value(),
-            options.syntax,
-            {
-                no_color: options.no_color,
-                add_syntaxes: _.chain(options.add_syntax).flatten().
-                                                    uniq().sort().value()
-            }
-        );
-    } else if (options.command == 'build-cson') {
-        syntaxdev.buildCson(options.in, options.out);
-    } else if (options.command == 'build-plist') {
-        syntaxdev.buildPList(options.in, options.out);
-    } else if (options.command == 'scopes') {
-        console.log(syntaxdev.listScopes(options.syntax).join('\n'));
+    try {
+        if (options.command == 'test') {
+            syntaxdev.test(
+                _.chain(options.tests).flatten().uniq().sort().value(),
+                options.syntax,
+                {
+                    no_color: options.no_color,
+                    add_syntaxes: _.chain(options.add_syntax).flatten().
+                                                        uniq().sort().value()
+                }
+            );
+        } else if (options.command == 'build-cson') {
+            syntaxdev.buildCson(options.in, options.out);
+        } else if (options.command == 'build-plist') {
+            syntaxdev.buildPList(options.in, options.out);
+        } else if (options.command == 'scopes') {
+            console.log(syntaxdev.listScopes(options.syntax).join('\n'));
+        }
+    } catch (e) {
+        if (e instanceof yaml.YAMLException) {
+             console.log(e.message);
+             process.exit(2);
+        } else {
+            throw e;
+        }
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,13 @@ function readGrammarFile(filename) {
                 });
         }
 
-        var schema = yaml.safeLoad(yamlSource);
+        try {
+            var schema = yaml.safeLoad(yamlSource);
+        } catch (e) {
+            // Annotate with file name.
+            e.message = filename + ': ' + e.message;
+            throw e;
+        }
 
         if (schema.repository
             && schema.repository.$apply


### PR DESCRIPTION
After this, an error is reported like this:

```
batavia:rdf-syntax-support bruce (master) $ npm -s test
src/turtle.syntax.yaml: bad indentation of a mapping entry at line 64, column 14:
         captures:
                 ^
```

Without it, it is just a stack trace with no info about where it happened in the actual files.