### PR TITLE
Add an option to overwrite tests output with the current results.

### DIFF
--- a/bin/syntaxdev.js
+++ b/bin/syntaxdev.js
@@ -43,6 +43,12 @@ testCli.addArgument([ '--no-color' ], {
     default: false
 });
 
+testCli.addArgument([ '--overwrite-tests' ], {
+    help: "Overwrite output for tests with the current output",
+    action: 'storeTrue',
+    default: false
+});
+
 testCli.addArgument([ '--syntax' ], {
     help: 'Syntax file in YAML format, ex: "--syntax FooLang.YAML-tmLanguage"',
     required: true
@@ -120,6 +126,7 @@ function main() {
             options.syntax,
             {
                 no_color: options.no_color,
+                overwrite_tests: options.overwrite_tests,
                 add_syntaxes: _.chain(options.add_syntax).flatten().
                                                     uniq().sort().value()
             }

--- a/index.js
+++ b/index.js
@@ -299,18 +299,25 @@ function testFile(file, grammar, options) {
     var result = tokenize(source);
 
     if (test != result) {
+        var extra = '';
+        if (options.overwrite_tests) {
+            extra = ', testfile updated';
+            var buf = [source, '\n\n\n', result];
+            fs.writeFileSync(file, buf.join('\n').trim() + '\n');
+        }
+
         if (test) {
             return {
                 file: file,
                 status: 'fail',
-                error: 'Output different from expected',
+                error: 'Output different from expected' + extra,
                 body: getDiff(test, result)
             }
         } else {
             return {
                 file: file,
                 status: 'fail',
-                error: 'No expected output set',
+                error: 'No expected output set' + extra,
                 body: result
             }
         }


### PR DESCRIPTION
Add `--overwrite-tests` flag that will result in overwriting the
testfiles using the currently produced output.